### PR TITLE
fix: ordering of `cursor` properties

### DIFF
--- a/src/default.css
+++ b/src/default.css
@@ -69,9 +69,9 @@ figure {
 
 /* CONSISTENT CURSOR */
 
-[aria-disabled="true" i], [disabled], [readonly] {
-	cursor: not-allowed; }
-
 ::file-selector-button, [role="button" i], [type="button" i], [type="reset" i], [type="submit" i], button,
 select, summary {
 	cursor: pointer; }
+
+[aria-disabled="true" i], [disabled], [readonly] {
+	cursor: not-allowed; }

--- a/src/routes/style/in-depth/default/+page.md
+++ b/src/routes/style/in-depth/default/+page.md
@@ -267,18 +267,6 @@ figure {
 
 ---
 
-For (usually interactive) elements currently not interactive `cursor` will consistently be `not-allowed`.
-
-```css
-[aria-disabled="true" i],
-[disabled],
-[readonly] {
-	cursor: not-allowed;
-}
-```
-
----
-
 All clickable elements gets `cursor: pointer`. The reason being how popular UI libraries, like Bootstrap, adds it for buttons and have made web users accustomed to it. Let’s embrace it and make it as consistent as it can be!
 
 ```css
@@ -291,6 +279,18 @@ button,
 select,
 summary {
 	cursor: pointer;
+}
+```
+
+---
+
+For (usually interactive) elements currently not interactive `cursor` will consistently be `not-allowed`. *Ruleset is below other `cursor` rules to take precedence.*
+
+```css
+[aria-disabled="true" i],
+[disabled],
+[readonly] {
+	cursor: not-allowed;
 }
 ```
 

--- a/src/where-default.css
+++ b/src/where-default.css
@@ -137,13 +137,13 @@
 
 /* CONSISTENT CURSOR */
 
-[aria-disabled="true" i], [disabled], [readonly] {
-	/* Consistent cursor for disabled elements */
-	cursor: not-allowed;
-}
-
 ::file-selector-button, [role="button" i], [type="button" i], [type="reset" i], [type="submit" i], button,
 select, summary {
 	/* Consistent cursor for clickable elements. */
 	cursor: pointer;
+}
+
+[aria-disabled="true" i], [disabled], [readonly] {
+	/* Consistent cursor for disabled elements */
+	cursor: not-allowed;
 }


### PR DESCRIPTION
Better ensure `not-allowed` cursor has precedence. E.g., when `button` has `type="button"` and `disabled`, cursor `pointer` would wrongly take precedence.